### PR TITLE
Support setting username

### DIFF
--- a/files/topology.yaml.tftpl
+++ b/files/topology.yaml.tftpl
@@ -27,7 +27,6 @@ tiflash_servers:
   - host: ${host}
     config:
       flash.disaggregated_mode: tiflash_write
-      storage.format_version: 5
       storage.s3.endpoint: http://s3.${s3_region}.amazonaws.com
       storage.s3.bucket: ${s3_bucket}
       storage.s3.root: /
@@ -38,8 +37,6 @@ tiflash_servers:
     config:
       delta_index_cache_size: 2000
       flash.disaggregated_mode: tiflash_compute
-      flash.use_autoscaler: false
-      storage.format_version: 5
       storage.s3.endpoint: http://s3.${s3_region}.amazonaws.com
       storage.s3.bucket: ${s3_bucket}
       storage.s3.root: /

--- a/locals_common.tf
+++ b/locals_common.tf
@@ -4,4 +4,5 @@ locals {
   n_tikv            = 3
   n_tiflash_write   = 2
   n_tiflash_compute = 3
+  username          = "ubuntu"
 }

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ resource "aws_instance" "tidb" {
 
   connection {
     type        = "ssh"
-    user        = "ubuntu"
+    user        = local.username
     private_key = file(local.master_ssh_key)
     host        = self.public_ip
   }
@@ -96,7 +96,7 @@ resource "aws_instance" "pd" {
 
   connection {
     type        = "ssh"
-    user        = "ubuntu"
+    user        = local.username
     private_key = file(local.master_ssh_key)
     host        = self.public_ip
   }
@@ -135,7 +135,7 @@ resource "aws_instance" "tikv" {
 
   connection {
     type        = "ssh"
-    user        = "ubuntu"
+    user        = local.username
     private_key = file(local.master_ssh_key)
     host        = self.public_ip
   }
@@ -174,7 +174,7 @@ resource "aws_instance" "tiflash_write" {
 
   connection {
     type        = "ssh"
-    user        = "ubuntu"
+    user        = local.username
     private_key = file(local.master_ssh_key)
     host        = self.public_ip
   }
@@ -213,7 +213,7 @@ resource "aws_instance" "tiflash_compute" {
 
   connection {
     type        = "ssh"
-    user        = "ubuntu"
+    user        = local.username
     private_key = file(local.master_ssh_key)
     host        = self.public_ip
   }
@@ -250,7 +250,7 @@ resource "aws_instance" "center" {
 
   connection {
     type        = "ssh"
-    user        = "ubuntu"
+    user        = local.username
     private_key = file(local.master_ssh_key)
     host        = self.public_ip
   }
@@ -259,7 +259,7 @@ resource "aws_instance" "center" {
     content = templatefile("./files/haproxy.cfg.tftpl", {
       tidb_hosts = aws_instance.tidb[*].private_ip,
     })
-    destination = "/home/ubuntu/haproxy.cfg"
+    destination = "/home/${local.username}/haproxy.cfg"
   }
 
   provisioner "file" {
@@ -271,7 +271,7 @@ resource "aws_instance" "center" {
       s3_region = local.region,
       s3_bucket = aws_s3_bucket.main.bucket,
     })
-    destination = "/home/ubuntu/topology.yaml"
+    destination = "/home/${local.username}/topology.yaml"
   }
 
   provisioner "remote-exec" {
@@ -284,11 +284,11 @@ resource "aws_instance" "center" {
   # add keys to access other hosts
   provisioner "file" {
     source      = local.master_ssh_key
-    destination = "/home/ubuntu/.ssh/id_rsa"
+    destination = "/home/${local.username}/.ssh/id_rsa"
   }
   provisioner "file" {
     source      = local.master_ssh_public
-    destination = "/home/ubuntu/.ssh/id_rsa.pub"
+    destination = "/home/${local.username}/.ssh/id_rsa.pub"
   }
   provisioner "remote-exec" {
     inline = [

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "ssh-center" {
-  value = "ssh ubuntu@${aws_instance.center.public_ip}"
+  value = "ssh ${local.username}@${aws_instance.center.public_ip}"
 }
 
 output "url-tidb-dashboard" {


### PR DESCRIPTION
When we deploy the cluster on another OS, "centos 7" for example, we need to change the default username. Or the scripts can not login to the target EC2 instances.